### PR TITLE
Fix logout cookie domain issue

### DIFF
--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   const response = NextResponse.json({ success: true });
 
   // Clear all Linear-related cookies
@@ -11,11 +11,19 @@ export async function GET() {
     "linear_workspace_url",
   ];
 
+  // Match the domain logic used when setting the cookies so they are
+  // properly cleared in production and local environments
+  const hostname = req.headers.get("host") || "";
+  const isLocalhost =
+    hostname.includes("localhost") || hostname.includes("127.0.0.1");
+  const domain = isLocalhost ? undefined : ".linear-top-issue.app";
+
   cookiesToClear.forEach((cookieName) => {
     response.cookies.set(cookieName, "", {
       path: "/",
       expires: new Date(0), // Set to past date to expire immediately
       maxAge: 0,
+      domain,
     });
   });
 


### PR DESCRIPTION
## Summary
- ensure logout route clears cookies with the same domain used when setting them

## Testing
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685cd5195d9483269d2cdaf8e4dd0dfe