### PR TITLE
Fix custom font path

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ export default async function Home() {
       : null;
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen p-8 font-[family-name:var(--font-geist-sans)]">
+    <div className="flex flex-col items-center justify-center min-h-screen p-8 font-[var(--font-geist-sans)]">
       <main className="flex flex-col gap-8 items-center w-full">
         <header className="flex items-center gap-3 mb-6 mt-2">
           <Image


### PR DESCRIPTION
## Summary
- use `font-[var(--font-geist-sans)]` so the custom font is applied

## Testing
- `yarn lint`
- `yarn build` *(fails: failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685cd85d7dfc8326b81123022eac6ecb